### PR TITLE
🐛 第一階層にtsconfig.json ファイルがないと上記のようなエラーが出るため、それを解消

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "eslint.workingDirectories": ["./app"]
+}


### PR DESCRIPTION
## イシュー番号
* Fix #28
* Fix #15 

## やったこと
* TypeScriptファイルの1行目で Parsing error: Cannot read file '.../tsconfig.json'.eslint （...の部分は自分のプロジェクトフォルダまでのパス）というエラーが表示されたため、それを解消。

## やらないこと
* なし

## できるようになること（ユーザ目線）
* なし

## できなくなること（ユーザ目線）
* なし

## チェック項目
 -TypeScriptファイルの1行目でエラー文が表示されないことを確認
下記はエラー内容
<img width="1003" alt="スクリーンショット 2023-04-16 15 06 44" src="https://user-images.githubusercontent.com/71067058/232275021-18f01c24-0747-458f-bc3d-fbc9523ad031.png">

## 動作確認
* チェック項目に同じ

## その他
* 参考にした記事
https://zenn.dev/taichifukumoto/scraps/45be5ffdfa8457