### PR TITLE
ホテル検索ページの一覧表示の見た目を作る

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,15 +80,15 @@ $ rspec
 
 ### Emoji
 
-#### 🌱 :seedling: Initial
-#### 🔥 :fire: Update features
-#### ✨ :sparkles: New features
-#### ♻️  :recycle: Refactoring
-#### 🐛 :bug: Bug
-#### 🎨 :art: Design
-#### 📚 :books: Document
-#### 🔧 :wrench: Configuration
-#### ⚡️ :zap: Improve
-#### 🚀 :rocket: Deploy
-#### 🧬 :dna: Merge
-#### 🧪 :test_tube: Test
+#### :seedling: Initial
+#### :fire: Update features
+#### :sparkles: New features
+#### :recycle: Refactoring
+#### :bug: Bug
+#### :art: Design
+#### :books: Document
+#### :wrench: Configuration
+#### :zap: Improve
+#### :rocket: Deploy
+#### :dna: Merge
+#### :test_tube: Test

--- a/frontend/pages/hotels.tsx
+++ b/frontend/pages/hotels.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import { HotelInfo } from '../types/hotels'
 import { getHotels } from '@/services/rakutenApi'
+import styles from '@/styles/hotels.module.css'
 
 const Hotels = () => {
   const [query, setQuery] = useState('')
@@ -37,19 +38,38 @@ const Hotels = () => {
         />
         <button onClick={handleButtonClick}>Search</button>
       </form>
-      {hotels.length > 0 ? (
-        hotels.map((value) => {
-          return (
-            <div key={value.hotel[0].hotelBasicInfo.hotelNo}>
-              {value.hotel[0].hotelBasicInfo.hotelName}
-              {value.hotel[0].hotelBasicInfo.hotelInformationUrl}
-              {value.hotel[0].hotelBasicInfo.hotelMinCharge}
-            </div>
-          )
-        })
-      ) : (
-        <div>No results</div>
-      )}
+      <table className={styles['table-container']}>
+        <thead>
+          <tr>
+            <th>ホテル名</th>
+            <th>URL</th>
+            <th>宿泊価格</th>
+          </tr>
+        </thead>
+        <tbody>
+          {hotels.length === 0 ? (
+            <tr>
+              <td colSpan={3}>No results</td>
+            </tr>
+          ) : (
+            hotels.map((value) => {
+              return (
+                <tr key={value.hotel[0].hotelBasicInfo.hotelNo}>
+                  <td>
+                    <h1>{value.hotel[0].hotelBasicInfo.hotelName}</h1>
+                  </td>
+                  <td>
+                    <a href={value.hotel[0].hotelBasicInfo.hotelInformationUrl}>
+                      {value.hotel[0].hotelBasicInfo.hotelInformationUrl}
+                    </a>
+                  </td>
+                  <td>{value.hotel[0].hotelBasicInfo.hotelMinCharge}円 ~</td>
+                </tr>
+              )
+            })
+          )}
+        </tbody>
+      </table>
     </>
   )
 }

--- a/frontend/styles/hotels.module.css
+++ b/frontend/styles/hotels.module.css
@@ -1,5 +1,5 @@
 .table-container {
-  width: 100%;
+  width: 90%;
   border-collapse: collapse;
   font-family: Arial, sans-serif;
   font-size: 14px;

--- a/frontend/styles/hotels.module.css
+++ b/frontend/styles/hotels.module.css
@@ -1,0 +1,35 @@
+.table-container {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: Arial, sans-serif;
+  font-size: 14px;
+  margin-top: 32px;
+  margin-bottom: 32px;
+  margin-left: 1rem;
+  margin-right: 1rem;
+}
+
+.table-container th,
+.table-container td {
+  padding: 8px;
+  border: 1px solid #ddd;
+}
+
+.table-container th {
+  background-color: #f2f2f2;
+}
+
+.table-container a {
+  color: #337ab7;
+  text-decoration: none;
+}
+
+.table-container a:hover {
+  text-decoration: underline;
+}
+
+.no-results {
+  text-align: center;
+  padding: 16px;
+  font-weight: bold;
+}


### PR DESCRIPTION
## イシュー番号
* Fix #24

## やったこと
* ホテル検索ページの検索結果一覧をテーブル表記にした
* readmeの余分な記述を削除（issue外）

## やらないこと
* 検索結果のページング機能の追加（https://github.com/mzw86020424/next-rakuten-app/issues/57 で対応）

## できるようになること（ユーザ目線）
* 検索結果がテーブル形式で表示される

## できなくなること（ユーザ目線）
* なし

## チェック項目
 - [x] `npm run lint`でエラーがでないことを確認
 - [ ] `rubocop -A`で整形されたことを確認
 - [ ] `rspec`でテストが通ることを確認

## 動作確認
* `http://localhost:8000/hotels`で検索した結果がテーブル形式になっている

[修正前]
![スクリーンショット 2023-06-25 12 23 07](https://github.com/mzw86020424/next-rakuten-app/assets/72555480/3301e36f-6512-4839-bd83-80169186efb9)


[修正後]
![スクリーンショット 2023-06-25 12 23 32](https://github.com/mzw86020424/next-rakuten-app/assets/72555480/bfb42535-6787-4ff7-9447-48c79a6ee1e6)


## その他
* ローカルでの動作確認までお願いします。