### PR TITLE
ヘッダーの遷移のテストを実装する

### DIFF
--- a/frontend/__tests__/components/navbar.tsx
+++ b/frontend/__tests__/components/navbar.tsx
@@ -15,17 +15,19 @@ describe('Navbarコンポーネント', () => {
 
   test('ホームをクリックすると正しいURLに遷移する', () => {
     const { getByText } = render(<Navbar />);
-    // "'homeLink' は 'null' の可能性があります。"の警告を回避するために、nullの場合は空のaタグを返す
-    const homeLink = getByText('ホーム').closest('a') ?? document.createElement('a');
+    const homeLink = getByText('ホーム').closest('a');
 
-    expect(homeLink.getAttribute('href')).toBe('/');
+    expect(homeLink).not.toBeNull();
+    // "'homeLink' は 'null' の可能性があります。"の警告を回避するために安全参照を実施
+    expect(homeLink?.getAttribute('href')).toBe('/');
   });
 
   test('ホテルをクリックすると正しいURLに遷移する', () => {
     const { getByText } = render(<Navbar />);
-    // "'hotelLink' は 'null' の可能性があります。"の警告を回避するために、nullの場合は空のaタグを返す
-    const hotelLink = getByText('ホテル').closest('a') ?? document.createElement('a');
-
-    expect(hotelLink.getAttribute('href')).toBe('/hotels');
+    const hotelLink = getByText('ホテル').closest('a');
+  
+    expect(hotelLink).not.toBeNull();
+    // "'hotelLink' は 'null' の可能性があります。"の警告を回避するために安全参照を実施
+    expect(hotelLink?.getAttribute('href')).toBe('/hotels');
   });
 })

--- a/frontend/__tests__/components/navbar.tsx
+++ b/frontend/__tests__/components/navbar.tsx
@@ -12,4 +12,20 @@ describe('Navbarコンポーネント', () => {
     expect(getByText('ホーム')).toBeTruthy()
     expect(getByText('ホテル')).toBeTruthy()
   })
+
+  test('ホームをクリックすると正しいURLに遷移する', () => {
+    const { getByText } = render(<Navbar />);
+    // "'homeLink' は 'null' の可能性があります。"の警告を回避するために、nullの場合は空のaタグを返す
+    const homeLink = getByText('ホーム').closest('a') ?? document.createElement('a');
+
+    expect(homeLink.getAttribute('href')).toBe('/');
+  });
+
+  test('ホテルをクリックすると正しいURLに遷移する', () => {
+    const { getByText } = render(<Navbar />);
+    // "'hotelLink' は 'null' の可能性があります。"の警告を回避するために、nullの場合は空のaタグを返す
+    const hotelLink = getByText('ホテル').closest('a') ?? document.createElement('a');
+
+    expect(hotelLink.getAttribute('href')).toBe('/hotels');
+  });
 })


### PR DESCRIPTION
## イシュー番号
* Fix #32

## やったこと
* ヘッダーのテストに以下を追加
  * homeを押下すると正しく遷移すること
  * hotelsを押下すると正しく遷移すること

## やらないこと
* なし

## できるようになること（ユーザ目線）
* jestを実行するとヘッダーの遷移テストが正常に実施される

## できなくなること（ユーザ目線）
* なし

## チェック項目
 - [ ] `npm run lint`でエラーがでないことを確認
 - [ ] `rubocop -A`で整形されたことを確認
 - [ ] `rspec`でテストが通ることを確認

## 動作確認
* `yarn test:ci`を実行して追加したテストが通ること

## その他
* なし