### PR TITLE
compose up時にmigrationを実行するようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ http://localhost:8000
 
 ```bash
 # フロント
-$ docker exec -ti { container ID } sh
+$ docker-compose exec front sh
 # api
-$ docker exec -ti { container ID } bash
+$ docker-compose exec api bash
 # railsコンテナから以下コマンドでDBに接続できる
 $ rails dbconsole
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       - 3000:3000
     volumes:
       - ./api:/app
-    command: rails server -b 0.0.0.0
+    command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails db:create && bundle exec rails db:migrate && bundle exec rails server -b 0.0.0.0"
   front: 
     build:
       context: ./frontend/


### PR DESCRIPTION
## イシュー番号
* Fix #37

## やったこと
* docker-compose up時にマイグレーションが実行されるよう設定する

## やらないこと
* なし

## できるようになること（ユーザ目線）
* docker-compose up時にマイグレーションが実行される

## できなくなること（ユーザ目線）
* なし

## チェック項目
 - [ ] `npm run lint`でエラーがでないことを確認
 - [ ] `rubocop -A`で整形されたことを確認
 - [ ] `rspec`でテストが通ることを確認

## 動作確認
* rails db:rollbackで全てのマイグレーションをdownにする→再度`docker-compose up`を実行する→rails コンテナでrails db:migrate:statusを実行する→すべてのマイグレーションがupの状態になっている

## その他
* なし