### PR TITLE
:sparkles: Add thumbnail images to hotel list for UX improvement/#70

### DIFF
--- a/frontend/__tests__/pages/hotels.tsx
+++ b/frontend/__tests__/pages/hotels.tsx
@@ -1,10 +1,69 @@
 import Hotels from '@/pages/hotels'
-import { render } from '@testing-library/react'
+import { render, fireEvent, waitFor, screen } from '@testing-library/react'
+import '@testing-library/jest-dom/extend-expect'
+import { getHotels } from '@/services/rakutenApi'
 
 describe('初期表示', () => {
   test('入力フォームと検索ボタンが表示されている', () => {
     const { getByText, getByPlaceholderText } = render(<Hotels />)
     expect(getByPlaceholderText('text')).toBeTruthy()
     expect(getByText('Search')).toBeTruthy()
+  })
+})
+
+// next/imageとgetHotelsのモック作成
+/* eslint-disable react/display-name, @next/next/no-img-element */
+jest.mock('next/image', () => ({ src, alt }: { src: string; alt: string }) => (
+  <img src={src} alt={alt} />
+))
+jest.mock('../../services/rakutenApi', () => ({
+  getHotels: jest.fn(),
+}))
+
+describe('Hotels', () => {
+  const mockHotelsResponse = {
+    hotels: [
+      {
+        hotel: [
+          {
+            hotelBasicInfo: {
+              hotelNo: '1',
+              hotelName: 'test hotel',
+              hotelInformationUrl: 'http://testhotel.com',
+              hotelImageUrl: 'http://testhotel.com/image.jpg',
+              hotelMinCharge: 1000,
+            },
+          },
+        ],
+      },
+    ],
+    pagingInfo: {
+      page: 1,
+      pageCount: 1,
+    },
+  }
+
+  beforeEach(() => {
+    ;(getHotels as jest.Mock).mockResolvedValue(mockHotelsResponse)
+  })
+
+  it('検索後に画像が表示されること', async () => {
+    render(<Hotels />)
+
+    const inputElement = screen.getByPlaceholderText('text')
+    const buttonElement = screen.getByText('Search')
+
+    fireEvent.change(inputElement, { target: { value: 'test' } })
+    fireEvent.click(buttonElement)
+
+    await waitFor(() => expect(getHotels).toHaveBeenCalledTimes(1))
+
+    const imageElement = screen.getByAltText('ホテルのサムネイル画像')
+
+    expect(imageElement).toBeInTheDocument()
+    expect(imageElement).toHaveAttribute(
+      'src',
+      mockHotelsResponse.hotels[0].hotel[0].hotelBasicInfo.hotelImageUrl
+    )
   })
 })

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,6 +1,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  images: {
+    domains: ['img.travel.rakuten.co.jp'],
+  },
 }
 
 module.exports = nextConfig

--- a/frontend/pages/hotels.tsx
+++ b/frontend/pages/hotels.tsx
@@ -69,7 +69,7 @@ const Hotels = () => {
                 <tr key={value.hotel[0].hotelBasicInfo.hotelNo}>
                   <td className="relative">
                     <Image
-                      src={value.hotel[0].hotelBasicInfo.hotelImageUrl}
+                      src={value.hotel[0].hotelBasicInfo.hotelThumbnailUrl}
                       alt="ホテルのサムネイル画像"
                       className="object-cover"
                       fill

--- a/frontend/pages/hotels.tsx
+++ b/frontend/pages/hotels.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import { HotelInfo } from '../types/hotels'
 import { getHotels } from '@/services/rakutenApi'
 import styles from '@/styles/hotels.module.css'
+import Image from 'next/image'
 
 const Hotels = () => {
   const [keyword, setKeyword] = useState('')
@@ -51,6 +52,7 @@ const Hotels = () => {
       <table className={styles['table-container']}>
         <thead>
           <tr>
+            <th>image</th>
             <th>ホテル名</th>
             <th>URL</th>
             <th>宿泊価格</th>
@@ -59,12 +61,21 @@ const Hotels = () => {
         <tbody>
           {hotels.length === 0 ? (
             <tr>
-              <td colSpan={3}>No results</td>
+              <td colSpan={4}>No results</td>
             </tr>
           ) : (
             hotels.map((value) => {
               return (
                 <tr key={value.hotel[0].hotelBasicInfo.hotelNo}>
+                  <td>
+                    <Image
+                      src={value.hotel[0].hotelBasicInfo.hotelImageUrl}
+                      alt="ホテルのサムネイル画像"
+                      width={300}
+                      height={200}
+                      quality={100}
+                    />
+                  </td>
                   <td>
                     <h1>{value.hotel[0].hotelBasicInfo.hotelName}</h1>
                   </td>

--- a/frontend/pages/hotels.tsx
+++ b/frontend/pages/hotels.tsx
@@ -67,12 +67,12 @@ const Hotels = () => {
             hotels.map((value) => {
               return (
                 <tr key={value.hotel[0].hotelBasicInfo.hotelNo}>
-                  <td>
+                  <td className="relative">
                     <Image
                       src={value.hotel[0].hotelBasicInfo.hotelImageUrl}
                       alt="ホテルのサムネイル画像"
-                      width={300}
-                      height={200}
+                      className="object-cover"
+                      fill
                       quality={100}
                     />
                   </td>

--- a/frontend/services/rakutenApi.ts
+++ b/frontend/services/rakutenApi.ts
@@ -2,7 +2,10 @@
 import { HotelSearchParam, HotelSearchResult } from '@/types/hotels'
 import 'cross-fetch/polyfill'
 
-export const getHotels = async (keyword: string, page: number): Promise<HotelSearchResult> => {
+export const getHotels = async (
+  keyword: string,
+  page: number
+): Promise<HotelSearchResult> => {
   const endpoint = 'Travel/KeywordHotelSearch'
   const params = {
     keyword: keyword,

--- a/frontend/styles/hotels.module.css
+++ b/frontend/styles/hotels.module.css
@@ -1,12 +1,9 @@
 .table-container {
-  width: 90%;
+  width: 95%;
   border-collapse: collapse;
   font-family: Arial, sans-serif;
   font-size: 14px;
-  margin-top: 32px;
-  margin-bottom: 32px;
-  margin-left: 1rem;
-  margin-right: 1rem;
+  margin: 32px auto;
 }
 
 .table-container th,
@@ -49,5 +46,5 @@
 .pagination-container a:hover {
   text-decoration: underline;
   color: #337ab7;
-  cursor:pointer;
+  cursor: pointer;
 }


### PR DESCRIPTION
## イシュー番号
* Fix #70 

## やったこと
* UX向上のため、ホテル一覧にサムネイル画像の列を一列目に追加した
* ホテル検索後に正常に画像が表示できるかどうかのテストを作成

## やらないこと
* なし

## できるようになること（ユーザ目線）
* ホテル検索の際、画像によりホテルのイメージを視覚的に知ることができるようになる。

## できなくなること（ユーザ目線）
* なし

## チェック項目
 - [ ] `npm run lint`でエラーがでないことを確認
 - [ ] `rubocop -A`で整形されたことを確認
 - [ ] `rspec`でテストが通ることを確認

## 動作確認
* yarn test:ci __tests__/pages/hotels.tsx がエラーなく通ることを確認。
* 実際にホテル検索（キーワード：新潟）を行い、画像が取得できることを確認。
![image](https://github.com/mzw86020424/next-rakuten-app/assets/71067058/87f8852a-4c69-453d-98f7-08a5f158bbe5)


## その他
* next.config.jsの内容を変更したため、dockerを立ち上げ直して確認してください。