### PR TITLE
ホテル一覧の各列の調整と名前をリンクにして、url列を削除する/#82

### DIFF
--- a/api/Gemfile.lock
+++ b/api/Gemfile.lock
@@ -119,6 +119,8 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.9)
+    nokogiri (1.15.1-aarch64-linux)
+      racc (~> 1.4)
     nokogiri (1.15.1-x86_64-linux)
       racc (~> 1.4)
     parallel (1.23.0)
@@ -226,6 +228,7 @@ GEM
     zeitwerk (2.6.8)
 
 PLATFORMS
+  aarch64-linux
   x86_64-linux
 
 DEPENDENCIES

--- a/frontend/pages/hotels.tsx
+++ b/frontend/pages/hotels.tsx
@@ -78,14 +78,13 @@ const Hotels = () => {
             hotels.map((value) => {
               return (
                 <tr key={value.hotel[0].hotelBasicInfo.hotelNo}>
-                  <td className="relative">
+                  <td className={`relative ${styles['image-cell']}`}>
                     <div className={styles['image-container']}>
                       <Image
                         src={value.hotel[0].hotelBasicInfo.hotelThumbnailUrl}
                         alt="ホテルのサムネイル画像"
-                        className="absolute top-0 left-0 w-full h-full object-cover"
                         layout="fill"
-                        quality={100}
+                        className={styles['image']}
                       />
                     </div>
                   </td>

--- a/frontend/pages/hotels.tsx
+++ b/frontend/pages/hotels.tsx
@@ -5,6 +5,7 @@ import { HotelInfo } from '../types/hotels'
 import { getHotels } from '@/services/rakutenApi'
 import styles from '@/styles/hotels.module.css'
 import Image from 'next/image'
+import Link from 'next/link'
 
 const Hotels = () => {
   const [keyword, setKeyword] = useState('')
@@ -42,19 +43,29 @@ const Hotels = () => {
 
   return (
     <>
-      <input
-        placeholder="text"
-        type="text"
-        value={keyword}
-        onChange={(x) => setKeyword(x.target.value)}
-      />
-      <button onClick={handleSearchClick}>Search</button>
+      <form
+        className="mt-4 mx-auto w-full max-w-md flex items-center px-4"
+        onSubmit={(e) => {
+          e.preventDefault() // デフォルトのフォーム送信を防ぐ
+          handleSearchClick()
+        }}
+      >
+        <input
+          className="flex-grow p-2 border rounded mr-2"
+          placeholder="text"
+          type="text"
+          value={keyword}
+          onChange={(x) => setKeyword(x.target.value)}
+        />
+        <button className="p-2 bg-blue-500 text-white rounded" type="submit">
+          Search
+        </button>
+      </form>
       <table className={styles['table-container']}>
         <thead>
           <tr>
             <th>image</th>
             <th>ホテル名</th>
-            <th>URL</th>
             <th>宿泊価格</th>
           </tr>
         </thead>
@@ -68,21 +79,24 @@ const Hotels = () => {
               return (
                 <tr key={value.hotel[0].hotelBasicInfo.hotelNo}>
                   <td className="relative">
-                    <Image
-                      src={value.hotel[0].hotelBasicInfo.hotelThumbnailUrl}
-                      alt="ホテルのサムネイル画像"
-                      className="object-cover"
-                      fill
-                      quality={100}
-                    />
+                    <div className={styles['image-container']}>
+                      <Image
+                        src={value.hotel[0].hotelBasicInfo.hotelThumbnailUrl}
+                        alt="ホテルのサムネイル画像"
+                        className="absolute top-0 left-0 w-full h-full object-cover"
+                        layout="fill"
+                        quality={100}
+                      />
+                    </div>
                   </td>
                   <td>
-                    <h1>{value.hotel[0].hotelBasicInfo.hotelName}</h1>
-                  </td>
-                  <td>
-                    <a href={value.hotel[0].hotelBasicInfo.hotelInformationUrl}>
-                      {value.hotel[0].hotelBasicInfo.hotelInformationUrl}
-                    </a>
+                    <Link
+                      href={value.hotel[0].hotelBasicInfo.hotelInformationUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      {value.hotel[0].hotelBasicInfo.hotelName}
+                    </Link>
                   </td>
                   <td>{value.hotel[0].hotelBasicInfo.hotelMinCharge}円 ~</td>
                 </tr>

--- a/frontend/styles/hotels.module.css
+++ b/frontend/styles/hotels.module.css
@@ -1,10 +1,18 @@
 .table-container {
-  width: 95%;
+  /* width: 95%; */
   border-collapse: collapse;
   font-family: Arial, sans-serif;
   font-size: 14px;
   margin: 18px auto;
   table-layout: fixed; /* 各セルの幅を均等にする */
+}
+
+/* 小さい画面のときにも両サイドにmarginを追加するため */
+@media (max-width: 810px) {
+  .table-container {
+    margin-left: 10px;
+    margin-right: 10px;
+  }
 }
 
 .table-container th,
@@ -15,7 +23,7 @@
 
 .table-container th {
   background-color: #f2f2f2;
-  width: 100%;
+  /* width: 100%; */
 }
 
 .table-container a {
@@ -27,10 +35,24 @@
   text-decoration: underline;
 }
 
+.image {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.image-cell {
+  width: 20%;
+}
+
 .image-container {
   width: 100%;
-  padding-bottom: 56.25%; /* 16:9のアスペクト比 */
   position: relative;
+  padding-bottom: 100%;
+  overflow: hidden;
 }
 
 .pagination-container {

--- a/frontend/styles/hotels.module.css
+++ b/frontend/styles/hotels.module.css
@@ -3,17 +3,19 @@
   border-collapse: collapse;
   font-family: Arial, sans-serif;
   font-size: 14px;
-  margin: 32px auto;
+  margin: 18px auto;
+  table-layout: fixed; /* 各セルの幅を均等にする */
 }
 
 .table-container th,
 .table-container td {
-  padding: 8px;
+  padding: 4px;
   border: 1px solid #ddd;
 }
 
 .table-container th {
   background-color: #f2f2f2;
+  width: 100%;
 }
 
 .table-container a {
@@ -25,10 +27,10 @@
   text-decoration: underline;
 }
 
-.no-results {
-  text-align: center;
-  padding: 16px;
-  font-weight: bold;
+.image-container {
+  width: 100%;
+  padding-bottom: 56.25%; /* 16:9のアスペクト比 */
+  position: relative;
 }
 
 .pagination-container {


### PR DESCRIPTION
## イシュー番号
* Fix #82 

## やったこと
* ホテル一覧の各列の調整と名前をリンクにして、url列を削除する

## やらないこと
* なし

## できるようになること（ユーザ目線）
* ホテル名をクリックすると、ホテルサイトに遷移できる

## できなくなること（ユーザ目線）
* なし

## チェック項目
 - [ ] `npm run lint`でエラーがでないことを確認
 - [ ] `rubocop -A`で整形されたことを確認
 - [ ] `rspec`でテストが通ることを確認

## 動作確認
* ホテルリンクをクリックし、新しいタブでリンクが開かれることを確認
* npm run test:ci __tests__/pages/hotels.tsx　にてエラーが出ないことを確認

## その他
* なし