### PR TITLE
【バックエンド】postsモデルのtitleとcaptionを必須項目に設定

### DIFF
--- a/api/app/models/post.rb
+++ b/api/app/models/post.rb
@@ -1,6 +1,6 @@
 class Post < ApplicationRecord
   belongs_to :user
 
-  validates :title, length: { maximum: 50 }
-  validates :caption, length: { maximum: 100 }
+  validates :title, presence: true, length: { maximum: 50 }
+  validates :caption, presence: true, length: { maximum: 100 }
 end

--- a/api/db/migrate/20230827053800_change_columns_in_posts.rb
+++ b/api/db/migrate/20230827053800_change_columns_in_posts.rb
@@ -1,0 +1,6 @@
+class ChangeColumnsInPosts < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :posts, :title, false
+    change_column_null :posts, :caption, false
+  end
+end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,11 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_24_002749) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_27_053800) do
   create_table "posts", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
-    t.string "title"
-    t.text "caption"
+    t.string "title", null: false
+    t.text "caption", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_posts_on_user_id"

--- a/api/spec/models/post_spec.rb
+++ b/api/spec/models/post_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe Post do
 
     context 'presence validations' do
       context 'titleが空の場合' do
-        let(:post) {Post.new(title: '', user:)}
+        let(:post) { described_class.new(title: '', user: user) }
+
         it 'バリデーションエラーが返されること' do
           expect(post).not_to be_valid
           expect(post.errors[:title]).to include("can't be blank")
@@ -14,7 +15,8 @@ RSpec.describe Post do
       end
 
       context 'captionが空の場合' do
-        let(:post) { Post.new(caption: '', user:)}
+        let(:post) { described_class.new(caption: '', user: user) }
+
         it 'バリデーションエラーが返されること' do
           expect(post).not_to be_valid
           expect(post.errors[:caption]).to include("can't be blank")
@@ -24,7 +26,8 @@ RSpec.describe Post do
 
     context 'タイトルの長さによるテスト' do
       context 'タイトルが51文字以上の場合' do
-        let(:post) { Post.new(title: 'a' * 51, user:) }
+        let(:post) { described_class.new(title: 'a' * 51, user: user) }
+
         it 'バリデーションエラーが返されること' do
           expect(post).not_to be_valid
           expect(post.errors[:title]).to include('is too long (maximum is 50 characters)')
@@ -32,7 +35,7 @@ RSpec.describe Post do
       end
 
       context 'タイトルが50文字の場合' do
-        let(:post) { Post.new(title: 'a' * 50, caption: 'Valid caption', user:) }
+        let(:post) { described_class.new(title: 'a' * 50, caption: 'Valid caption', user: user) }
 
         it 'バリデーションエラーが表示されないこと' do
           expect(post).to be_valid
@@ -42,7 +45,7 @@ RSpec.describe Post do
 
     context 'キャプションの長さによるテスト' do
       context 'キャプションが101文字以上の場合' do
-        let(:post) { Post.new(caption: 'a' * 101, user:) }
+        let(:post) { described_class.new(caption: 'a' * 101, user: user) }
 
         it 'バリデーションエラーが返されること' do
           expect(post).not_to be_valid
@@ -51,7 +54,7 @@ RSpec.describe Post do
       end
 
       context 'キャプションが100文字の場合' do
-        let(:post) { Post.new(title: 'Valid title',caption: 'a' * 100, user:) }
+        let(:post) { described_class.new(title: 'Valid title', caption: 'a' * 100, user: user) }
 
         it 'バリデーションエラーが表示されないこと' do
           expect(post).to be_valid
@@ -60,4 +63,3 @@ RSpec.describe Post do
     end
   end
 end
-

--- a/api/spec/models/post_spec.rb
+++ b/api/spec/models/post_spec.rb
@@ -3,6 +3,25 @@ require 'rails_helper'
 RSpec.describe Post do
   describe 'validations' do
     let!(:user) { create(:user) }
+
+    context 'presence validations' do
+      context 'titleが空の場合' do
+        let(:post) {Post.new(title: '', user:)}
+        it 'バリデーションエラーが返されること' do
+          expect(post).not_to be_valid
+          expect(post.errors[:title]).to include("can't be blank")
+        end
+      end
+
+      context 'captionが空の場合' do
+        let(:post) { Post.new(caption: '', user:)}
+        it 'バリデーションエラーが返されること' do
+          expect(post).not_to be_valid
+          expect(post.errors[:caption]).to include("can't be blank")
+        end
+      end
+    end
+
     context 'タイトルの長さによるテスト' do
       context 'タイトルが51文字以上の場合' do
         let(:post) { Post.new(title: 'a' * 51, user:) }
@@ -13,7 +32,7 @@ RSpec.describe Post do
       end
 
       context 'タイトルが50文字の場合' do
-        let(:post) { Post.new(title: 'a' * 50, user:) }
+        let(:post) { Post.new(title: 'a' * 50, caption: 'Valid caption', user:) }
 
         it 'バリデーションエラーが表示されないこと' do
           expect(post).to be_valid
@@ -32,7 +51,7 @@ RSpec.describe Post do
       end
 
       context 'キャプションが100文字の場合' do
-        let(:post) { Post.new(caption: 'a' * 100, user:) }
+        let(:post) { Post.new(title: 'Valid title',caption: 'a' * 100, user:) }
 
         it 'バリデーションエラーが表示されないこと' do
           expect(post).to be_valid

--- a/api/spec/models/user_spec.rb
+++ b/api/spec/models/user_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe User do
   describe 'validations' do
-    let(:user) { User.new(sub: sub_value) }
+    let(:user) { described_class.new(sub: sub_value) }
 
     context 'subが存在しない場合' do
       let(:sub_value) { nil }


### PR DESCRIPTION
## イシュー番号
* Fix #92 

## やったこと
* postsモデルのtitleとcaptionを必須項目に設定。

## やらないこと
* なし

## できるようになること（ユーザ目線）
* なし

## できなくなること（ユーザ目線）
* なし

## チェック項目
 - [ ] `npm run lint`でエラーがでないことを確認
 - [ ] `rubocop -A`で整形されたことを確認
 - [ ] `rspec`でテストが通ることを確認

## 動作確認
* 問題なく投稿できることを確認。テストが通ることを確認。

## その他
* maigrationファイルを追加したため、rails db:migrateをしてください。